### PR TITLE
Upgrade to latest spray version and latest akka 2.3.x

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,8 +23,8 @@ object Dependencies {
   )
 
   val kamonVersion      = "0.6.3"
-  val akkaVersion       = "2.3.14"
-  val sprayVersion      = "1.3.3"
+  val akkaVersion       = "2.3.16"
+  val sprayVersion      = "1.3.4"
   val slf4jVersion      = "1.7.7"
 
   val kamonCore         = "io.kamon"                  %%  "kamon-core"            % kamonVersion
@@ -37,15 +37,15 @@ object Dependencies {
   val sprayRouting      = "io.spray"                  %%  "spray-routing"         % sprayVersion
   val sprayTestkit      = "io.spray"                  %%  "spray-testkit"         % sprayVersion
   val sprayClient       = "io.spray"                  %%  "spray-client"          % sprayVersion
-  val sprayJson         = "io.spray"                  %%  "spray-json"            % "1.3.1"
-  val sprayJsonLenses   = "net.virtual-void"          %%  "json-lenses"           % "0.6.0"
+  val sprayJson         = "io.spray"                  %%  "spray-json"            % "1.3.3"
+  val sprayJsonLenses   = "net.virtual-void"          %%  "json-lenses"           % "0.6.1"
 
   val libThrift         = "org.apache.thrift"         %   "libthrift"             % "0.9.2"
   val slf4jApi          = "org.slf4j"                 %   "slf4j-api"             % slf4jVersion
   val slf4jnop          = "org.slf4j"                 %   "slf4j-nop"             % slf4jVersion
 
 
-  val scalatest         = "org.scalatest"             %%  "scalatest"             % "2.2.4"
+  val scalatest         = "org.scalatest"             %%  "scalatest"             % "3.0.1"
 
   def compileScope   (deps: ModuleID*): Seq[ModuleID] = deps map (_ % "compile")
   def testScope      (deps: ModuleID*): Seq[ModuleID] = deps map (_ % "test")


### PR DESCRIPTION
I was able to build without a dependency on json-lenses but kept it just in case.
There is no json-lenses scala 2.12 release yet. https://github.com/jrudolph/json-lenses/issues/27