### PR TITLE
Remove json-lenses dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,5 +23,5 @@ lazy val root = (project in file("."))
   .settings(formatSettings: _*)
   .settings(
       libraryDependencies ++=
-        compileScope(kamonCore, sprayCan, sprayClient, sprayRouting, sprayJson, sprayJsonLenses, akkaSlf4j, libThrift) ++
+        compileScope(kamonCore, sprayCan, sprayClient, sprayRouting, sprayJson, akkaSlf4j, libThrift) ++
         testScope(scalatest, akkaTestKit, slf4jApi, slf4jnop))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,6 @@ object Dependencies {
   val sprayTestkit      = "io.spray"                  %%  "spray-testkit"         % sprayVersion
   val sprayClient       = "io.spray"                  %%  "spray-client"          % sprayVersion
   val sprayJson         = "io.spray"                  %%  "spray-json"            % "1.3.3"
-  val sprayJsonLenses   = "net.virtual-void"          %%  "json-lenses"           % "0.6.1"
 
   val libThrift         = "org.apache.thrift"         %   "libthrift"             % "0.9.2"
   val slf4jApi          = "org.slf4j"                 %   "slf4j-api"             % slf4jVersion


### PR DESCRIPTION
I did a quick smoke test with kamon-spm 0.6.3 which involved removing the json-lenses jar from my classpath. My JVM was still able to publish metrics to SPM Sematext with no apparent issues.